### PR TITLE
Add AI core officers

### DIFF
--- a/src/starlords/util/LordFleetFactory.java
+++ b/src/starlords/util/LordFleetFactory.java
@@ -50,19 +50,24 @@ public class LordFleetFactory extends FleetFactoryV3 {
             }
             if (ship.isFlagship()) {
                 ship.setCaptain(lord.getLordAPI());
-            } else if (!Misc.isAutomated(ship)) {
-                PersonAPI officer = lord.getLordAPI().getFaction().createRandomPerson();
-                officer.setPersonality(lord.getTemplate().battlePersonality);
-                upskillOfficer(officer, true);
-                Misc.setUnremovable(officer, true);
-                lord.getLordAPI().getFleet().getFleetData().addOfficer(officer);
-                ship.setCaptain(officer);
             } else {
-                //modify this so it's dynamic... eventually
-                AICoreOfficerPlugin plugin = Misc.getAICoreOfficerPlugin(Commodities.BETA_CORE);
-                PersonAPI aiOfficer = plugin.createPerson(Commodities.BETA_CORE, Factions.REMNANTS, new Random());
-                ship.setCaptain(aiOfficer);
-                Misc.setUnremovable(aiOfficer, true);
+                PersonAPI officer = lord.getLordAPI().getFaction().createRandomPerson();
+
+                boolean isAuxiliaryAIShip = !officer.isAICore() && Misc.isAutomated(ship);
+
+                if (isAuxiliaryAIShip) {
+                    //modify this so it's dynamic... eventually
+                    AICoreOfficerPlugin plugin = Misc.getAICoreOfficerPlugin(Commodities.BETA_CORE);
+                    PersonAPI aiOfficer = plugin.createPerson(Commodities.BETA_CORE, Factions.REMNANTS, new Random());
+                    ship.setCaptain(aiOfficer);
+                    Misc.setUnremovable(aiOfficer, true);
+                } else {
+                    officer.setPersonality(lord.getTemplate().battlePersonality);
+                    upskillOfficer(officer, true);
+                    Misc.setUnremovable(officer, true);
+                    lord.getLordAPI().getFleet().getFleetData().addOfficer(officer);
+                    ship.setCaptain(officer);
+                }
             }
         }
     }

--- a/src/starlords/util/LordFleetFactory.java
+++ b/src/starlords/util/LordFleetFactory.java
@@ -1,6 +1,7 @@
 package starlords.util;
 
 import com.fs.starfarer.api.Global;
+import com.fs.starfarer.api.campaign.AICoreOfficerPlugin;
 import com.fs.starfarer.api.campaign.CampaignFleetAPI;
 import com.fs.starfarer.api.campaign.CargoAPI;
 import com.fs.starfarer.api.campaign.SectorEntityToken;
@@ -14,9 +15,7 @@ import com.fs.starfarer.api.fleet.FleetMemberType;
 import com.fs.starfarer.api.fleet.ShipRolePick;
 import com.fs.starfarer.api.impl.campaign.fleets.FleetFactoryV3;
 import com.fs.starfarer.api.impl.campaign.fleets.FleetParamsV3;
-import com.fs.starfarer.api.impl.campaign.ids.Commodities;
-import com.fs.starfarer.api.impl.campaign.ids.HullMods;
-import com.fs.starfarer.api.impl.campaign.ids.Skills;
+import com.fs.starfarer.api.impl.campaign.ids.*;
 import com.fs.starfarer.api.util.Misc;
 import starlords.person.Lord;
 import starlords.person.LordPersonality;
@@ -51,13 +50,19 @@ public class LordFleetFactory extends FleetFactoryV3 {
             }
             if (ship.isFlagship()) {
                 ship.setCaptain(lord.getLordAPI());
-            } else {
+            } else if (!Misc.isAutomated(ship)) {
                 PersonAPI officer = lord.getLordAPI().getFaction().createRandomPerson();
                 officer.setPersonality(lord.getTemplate().battlePersonality);
                 upskillOfficer(officer, true);
                 Misc.setUnremovable(officer, true);
                 lord.getLordAPI().getFleet().getFleetData().addOfficer(officer);
                 ship.setCaptain(officer);
+            } else {
+                //modify this so it's dynamic... eventually
+                AICoreOfficerPlugin plugin = Misc.getAICoreOfficerPlugin(Commodities.BETA_CORE);
+                PersonAPI aiOfficer = plugin.createPerson(Commodities.BETA_CORE, Factions.REMNANTS, new Random());
+                ship.setCaptain(aiOfficer);
+                Misc.setUnremovable(aiOfficer, true);
             }
         }
     }


### PR DESCRIPTION
Currently, functionality for AI-crewed ships is missing. I added an implementation that allows for setting AI core officers to any automated ship listed in the JSON, through a vanilla plugin that allows for their creation by receiving the string identifier of cores rank gamma through alpha (and possibly omega). Feel free to consult with Deluth in whether it's worth adding as it is to the maintenance version. 

![image](https://github.com/user-attachments/assets/bf0055f2-6ef4-47ee-a806-da47cc024744)


I have also thought of some ideas to make AI fleets more flexible and dynamic rather than just setting them to a fixed value. These would be:

1. Scale AI core quality off the Lord's wealth

Pretty simple here. If the Lord is wealthy enough, he can 'buy' more expensive cores and thus get more formidable AI ships. The only problem with this one is that it locks AI core progression to vanilla stuff mostly.

2. Jsonize AI core id so each Lord 'buys' a different degree of AI core, always:

This is my personal favorite. By setting a new Json field you can make it so a Lord could potentially set up his automated ships with any sort of moddable AI core as long as the plugin for its generation exists, Daemon cores babeyyy!!!

There's probably a way to work both in, probably with some sort of ordered / weighed list and rng magic, but this was fairly simple stuff that I just made up. 