### PR TITLE
(Second In Command) Cross-mod update: Populate lord fleets to max level, up to 3 

### DIFF
--- a/src/starlords/util/LordFleetFactory.java
+++ b/src/starlords/util/LordFleetFactory.java
@@ -76,7 +76,7 @@ public class LordFleetFactory extends FleetFactoryV3 {
             }
         }
 
-        if (Utils.secondInCommandEnabled() && !lord.getTemplate().executiveOfficers.isEmpty()) {
+        if (Utils.secondInCommandEnabled()) {
             SCLordsFactory.populateExecutiveOfficers(lord);
         }
     }

--- a/src/starlords/util/crossmod/SCLordsFactory.java
+++ b/src/starlords/util/crossmod/SCLordsFactory.java
@@ -3,17 +3,27 @@ package starlords.util.crossmod;
 import com.fs.starfarer.api.util.WeightedRandomPicker;
 import second_in_command.SCData;
 import second_in_command.SCUtils;
-import second_in_command.misc.PotentialPick;
 import second_in_command.specs.*;
 import starlords.person.Lord;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 public class SCLordsFactory {
     public static void populateExecutiveOfficers(Lord lord) {
         SCData scData = SCUtils.getFleetData(lord.getFleet());
+
+        if (lord.getTemplate().executiveOfficers.size() < 3) {
+            WeightedRandomPicker<SCBaseAptitudePlugin> aptitudePicker = fillRandomAptitudePicker(
+                    lord.getTemplate().executiveOfficers.keySet().stream().toList(),
+                    scData,
+                    lord
+            );
+            for (int i = lord.getTemplate().executiveOfficers.size(); i < 3; i++) {
+                String aptitudeId = pickRandomAptitude(aptitudePicker);
+                lord.getTemplate().executiveOfficers.put(aptitudeId, new ArrayList<>());
+            }
+        }
 
         int currentSlot = 0;
         for (String aptitudeId : lord.getTemplate().executiveOfficers.keySet() ) {
@@ -26,15 +36,30 @@ public class SCLordsFactory {
                 unlockedSkills.add(skillId);
                 currentSkill++;
             }
-            for (int i = currentSkill; i < 6; i++) {
+            for (int i = currentSkill; i < 5; i++) {
                 String newSkill = pickRandomSkill(officer, unlockedSkills);
                 if (newSkill != null) {
                     officer.addSkill(newSkill);
+                    unlockedSkills.add(newSkill);
                 }
             }
             scData.setOfficerInSlot(currentSlot, officer);
             currentSlot++;
         }
+    }
+
+    private static WeightedRandomPicker<SCBaseAptitudePlugin> fillRandomAptitudePicker(List<String> unlockedAptitudes, SCData data, Lord lord) {
+        WeightedRandomPicker<SCBaseAptitudePlugin> aptitudePicker = new WeightedRandomPicker<>();
+        List<SCBaseAptitudePlugin> availableAptitudes = SCSpecStore.getAptitudeSpecs().stream().map(SCAptitudeSpec::getPlugin).toList();
+        availableAptitudes = availableAptitudes.stream().filter(aptitude -> !unlockedAptitudes.contains(aptitude.getId())).toList();
+        for (SCBaseAptitudePlugin availableAptitude : availableAptitudes) {
+            aptitudePicker.add(availableAptitude, availableAptitude.getNPCFleetSpawnWeight(data, lord.getFleet()) + 0.01f);
+        }
+        return aptitudePicker;
+    }
+
+    private static String pickRandomAptitude(WeightedRandomPicker<SCBaseAptitudePlugin> aptitudePicker) {
+        return aptitudePicker.pickAndRemove().getId();
     }
 
     private static String pickRandomSkill(SCOfficer officer, List<String> unlockedSkills) {


### PR DESCRIPTION
**Change**

Allow officers to load up to 3 XOs in their fleets and load them up to max level. Also fixes a bug where skills could get re-picked, preventing a true max lvlup. 

**Purpose of change**

See [previous mr](https://github.com/Alaricdragon/Starlords_Temp/pull/20).

