### PR TITLE
0.3.48 - patch 1

### DIFF
--- a/data/config/LunaSettings.csv
+++ b/data/config/LunaSettings.csv
@@ -17,6 +17,7 @@ Other_requiredRepForKnowledgeOfCurAction,Required reputation for knowing a lords
 Other_showAllLordsIntelByDefault,Show lords in the intel tab before you meet them,Boolean,false,,,,,Other
 Other_showMessageLordCaptureReleaseEscape,"Show UI Message when lords are captured, released or escape",Boolean,false,,This setting is always true for lords of your own faction or faction you have a commission with.,,,Other
 Other_playerExtraCouncilWeight,Player Extra Own Faction Council Weight,Int,2000,,This setting adds the configured value to the player's weight in own faction's council votes..,0,5000,Other
+Other_minStabilityToPreventFiefDefection,"Minimum Stability to Prevent Fief Defection",Int,7,,"This setting sets the minimum stability the fief/market needs to have in order to not defect with the lord. If the market has lower stability than the configured value, then it will defect.",0,10,Other
 ,,,,,,,,
 Header_lordFleetSettings,,Header,Lord fleet settings,,,,,Other
 Other_maxSMods,Maximum number of S-Mods a starlord can have on each ship,Int,3,,,0,100,Other

--- a/data/config/starlord_settings.json
+++ b/data/config/starlord_settings.json
@@ -7,6 +7,7 @@
   "showAllLordsIntelByDefault": false,
   "showMessageLordCaptureReleaseEscape": false,
   "playerExtraCouncilWeight": 2000,
+  "minStabilityToPreventFiefDefection": 7,
   "features_canPlayerFactionBeAttacked": true,
   "features_canPlayerFactionBeAttackedBeforeStarlords": false,
 

--- a/data/lords/lords.json
+++ b/data/lords/lords.json
@@ -26,6 +26,14 @@
       "legion_xiv_Elite": 10,
       "onslaught_Elite": 15,
       "onslaught_xiv_Elite": 10
+    },
+    "alignments": {
+      "CORPORATE": -0.5,
+      "TECHNOCRATIC": -0.5,
+      "MILITARIST": 0.5,
+      "HIERARCHICAL": 0.5,
+      "DIPLOMATIC": -0.5,
+      "IDEOLOGICAL": 0.5
     }
   },
   "Vartan Shin": {

--- a/src/starlords/console/AddLordFief.java
+++ b/src/starlords/console/AddLordFief.java
@@ -8,6 +8,7 @@ import starlords.controllers.FiefController;
 import starlords.controllers.LordController;
 import starlords.controllers.RelationController;
 import starlords.person.Lord;
+import starlords.util.Utils;
 
 public class AddLordFief implements BaseCommand {
 
@@ -29,9 +30,15 @@ public class AddLordFief implements BaseCommand {
 
         MarketAPI market = Global.getSector().getEconomy().getMarket(argsArr[1]);
         if (market == null) {
-            Console.showMessage("Invalid market id.");
+            Console.showMessage("Invalid market id, trying name.");
+        }
+
+        market = Utils.getFactionMarket(argsArr[1], lord.getFaction().getId());
+        if (market == null) {
+            Console.showMessage("Invalid market id or name.");
             return CommandResult.ERROR;
         }
+
         if (!market.getFaction().equals(lord.getFaction())) {
             Console.showMessage("Cannot grant market to a lord of a different faction.");
             return CommandResult.ERROR;

--- a/src/starlords/controllers/EventController.java
+++ b/src/starlords/controllers/EventController.java
@@ -115,9 +115,13 @@ public class EventController extends BaseIntelPlugin {
     public static void addRaid(LordEvent raid) {
         getInstance().raids.add(raid);
         FactionAPI targetFaction = raid.getTarget().getFaction();
-        if (raid.getOriginator() != null && (targetFaction.equals(Utils.getRecruitmentFaction())
-                || targetFaction.equals(Global.getSector().getPlayerFaction()))) {
-            Global.getSector().getIntelManager().addIntel(new HostileEventIntelPlugin(raid));
+        FactionAPI playerFaction = Global.getSector().getPlayerFaction();
+        Lord originator = raid.getOriginator();
+        if (originator != null)
+            if (targetFaction.equals(Utils.getRecruitmentFaction())
+                    || targetFaction.equals(playerFaction)
+                    || originator.getFaction().equals(Utils.getRecruitmentFaction())) {
+                Global.getSector().getIntelManager().addIntel(new HostileEventIntelPlugin(raid));
         }
         LordAI.triggerPreemptingEvent(raid);
     }

--- a/src/starlords/faction/LawProposal.java
+++ b/src/starlords/faction/LawProposal.java
@@ -96,6 +96,7 @@ public class LawProposal {
             if (!faction.equals(Global.getSector().getPlayerFaction())) {
                 ctr += PoliticsController.getPoliticalWeight(LordController.getPlayerLord());
             } else  {
+                ctr += PoliticsController.PLAYER_EXTRA_COUNCIL_WEIGHT;
                 ctr *= PoliticsController.getLiegeMultiplier(Global.getSector().getPlayerFaction());
             }
         }

--- a/src/starlords/listeners/BattleListener.java
+++ b/src/starlords/listeners/BattleListener.java
@@ -8,6 +8,7 @@ import org.apache.log4j.Logger;
 import starlords.controllers.*;
 import starlords.person.Lord;
 import starlords.person.LordAction;
+import starlords.person.LordEvent;
 import starlords.person.LordRequest;
 import starlords.util.DefectionUtils;
 import starlords.util.LordFleetFactory;
@@ -303,6 +304,15 @@ public class BattleListener extends BaseCampaignEventListener {
 				    marshal.setControversy(Math.min(100, marshal.getControversy() + 1));
 			    }
 		    //}
+
+		    //Check if lord was defeated in a battle that was leading a campaign, and if so, remove the campaign
+		    LordEvent campaign = EventController.getCurrentCampaign(defeated.getFaction());
+		    if (campaign != null) {
+			    if (campaign.getOriginator() != null)
+				    if (campaign.getOriginator().equals(defeated))
+					    EventController.endCampaign(campaign);
+		    }
+
 
 		    String afterPrisonerCalculation = "[Star Lords] Winner Lords:" + System.lineSeparator()
 				    + Utils.printLordsWithPrisoners(winnerLords) + System.lineSeparator()

--- a/src/starlords/lunaSettings/StoredSettings.java
+++ b/src/starlords/lunaSettings/StoredSettings.java
@@ -20,11 +20,8 @@ import starlords.generator.types.fleet.LordFleetGenerator_Desing;
 import starlords.generator.types.fleet.LordFleetGenerator_Hullmod;
 import starlords.generator.types.fleet.LordFleetGenerator_System;
 import starlords.ui.LordsIntelPlugin;
-import starlords.util.Constants;
-import starlords.util.LordFleetFactory;
+import starlords.util.*;
 import starlords.util.SModSupport.SModSet;
-import starlords.util.Utils;
-import starlords.util.WeightedRandom;
 import starlords.util.dialogControler.DialogSet;
 import starlords.util.factionUtils.FactionTemplateController;
 
@@ -237,6 +234,7 @@ public class StoredSettings {
         LordsIntelPlugin.setAllowLordsToBeViewed(LunaSettings.getBoolean(Constants.MOD_ID,"Other_showAllLordsIntelByDefault"));
         Utils.setShowMessageLordCaptureReleaseEscape(LunaSettings.getBoolean(Constants.MOD_ID,"Other_showMessageLordCaptureReleaseEscape"));
         PoliticsController.PLAYER_EXTRA_COUNCIL_WEIGHT = LunaSettings.getInt(Constants.MOD_ID,"Other_playerExtraCouncilWeight");
+        DefectionUtils.MIN_STABILITY_TO_PREVENT_FIEF_DEFECTION = LunaSettings.getInt(Constants.MOD_ID,"Other_minStabilityToPreventFiefDefection");
         //player faction being attacked settings
         TargetUtils.setCanPlayerBeAttacked(LunaSettings.getBoolean(Constants.MOD_ID,"features_canPlayerFactionBeAttacked"));
         TargetUtils.setCanPlayerBeAttackedBeforeStarlords(LunaSettings.getBoolean(Constants.MOD_ID,"features_canPlayerFactionBeAttackedBeforeStarlords"));
@@ -438,6 +436,7 @@ public class StoredSettings {
         LordsIntelPlugin.setAllowLordsToBeViewed(json.getBoolean("showAllLordsIntelByDefault"));
         Utils.setShowMessageLordCaptureReleaseEscape(json.getBoolean("showMessageLordCaptureReleaseEscape"));
         PoliticsController.PLAYER_EXTRA_COUNCIL_WEIGHT = json.getInt("playerExtraCouncilWeight");
+        DefectionUtils.MIN_STABILITY_TO_PREVENT_FIEF_DEFECTION = json.getInt("minStabilityToPreventFiefDefection");
         TargetUtils.setCanPlayerBeAttacked(json.getBoolean("features_canPlayerFactionBeAttacked"));
         TargetUtils.setCanPlayerBeAttackedBeforeStarlords(json.getBoolean("features_canPlayerFactionBeAttackedBeforeStarlords"));
 

--- a/src/starlords/person/Lord.java
+++ b/src/starlords/person/Lord.java
@@ -156,7 +156,12 @@ public class Lord {
 
         if (Utils.nexEnabled()) {
             persistentData.put("alignments", new HashMap<Alliance.Alignment, Float>());
-            this.alignments = NexerlinUtilitys.generateLordAlignments(this);
+            if (template.alignments.isEmpty()) {
+                this.alignments = NexerlinUtilitys.generateLordAlignments(this);
+            }
+            else {
+                this.alignments = NexerlinUtilitys.generateLordAlignmentsFromTemplate(this);
+            }
             persistentData.put("alignments", alignments);
         }
 

--- a/src/starlords/person/LordTemplate.java
+++ b/src/starlords/person/LordTemplate.java
@@ -26,6 +26,7 @@ public final class LordTemplate {
     public final String flagShip;
     public final String lore;
     public final HashMap<String, Integer> shipPrefs;
+    public final HashMap<String, Float> alignments;
     public final HashMap<String, Integer> customSkills;
 
     public final HashMap<String, Integer> customLordSMods;
@@ -94,6 +95,16 @@ public final class LordTemplate {
             String key = (String) it.next();
             shipPrefs.put(key, prefJson.getInt(key));
         }
+        // Alignments initialization
+        alignments = new HashMap<>();
+        if (template.has("alignments")) {
+            JSONObject alignmentsJson = template.getJSONObject("alignments");
+            for (Iterator it = alignmentsJson.keys(); it.hasNext(); ) {
+                String key = (String) it.next();
+                alignments.put(key, (float) alignmentsJson.getDouble(key));
+            }
+        }
+
         customSkills = new HashMap<>();
         if (template.has("customSkills")) {
             JSONObject skillJson = template.getJSONObject("customSkills");
@@ -191,6 +202,7 @@ public final class LordTemplate {
         level = template.level;
         ranking = template.ranking;
         shipPrefs = template.shipPrefs;
+        alignments = new HashMap<>();
         customSkills = new HashMap<>();
         executiveOfficers = new HashMap<>();
         customLordSMods = new HashMap<String,Integer>();

--- a/src/starlords/util/DefectionUtils.java
+++ b/src/starlords/util/DefectionUtils.java
@@ -30,6 +30,7 @@ import static starlords.util.Constants.COMPLETELY_UNJUSTIFIED;
 public class DefectionUtils {
 
 	private static final Logger log = Logger.getLogger(DefectionUtils.class);
+	public static int MIN_STABILITY_TO_PREVENT_FIEF_DEFECTION;
 
 	// -50 to +50, higher means prefers other faction
     public static int computeRelativeFactionPreference(Lord lord, FactionAPI newFaction) {
@@ -270,7 +271,7 @@ public class DefectionUtils {
         // changed this into faction that can be attacked. I considered this for all minor factions, but some of them can be attacked, and such can get back there markets so...
         if (includeFiefs && FactionTemplateController.getTemplate(oldFaction).isCanLordsTakeFiefsWithDefection() && !FactionTemplateController.getTemplate(faction).isCanLordsTakeFiefsWithDefection()) {
             for (SectorEntityToken fief : new ArrayList<>(lord.getFiefs())) {
-                if (fief.getMarket().getStabilityValue() < 7) {
+                if (fief.getMarket().getStabilityValue() < MIN_STABILITY_TO_PREVENT_FIEF_DEFECTION) {
 	                fief.getMarket().setFactionId(faction.getId());
 	                fief.setFaction(faction.getId());
 

--- a/src/starlords/util/NexerlinUtilitys.java
+++ b/src/starlords/util/NexerlinUtilitys.java
@@ -2,6 +2,7 @@ package starlords.util;
 
 import com.fs.starfarer.api.Global;
 import com.fs.starfarer.api.campaign.FactionAPI;
+import com.fs.starfarer.api.campaign.FleetActionTextProvider;
 import com.fs.starfarer.api.campaign.RepLevel;
 import com.fs.starfarer.api.campaign.econ.MarketAPI;
 import com.fs.starfarer.api.impl.campaign.missions.academy.GACelestialObject;
@@ -16,6 +17,7 @@ import starlords.person.Lord;
 import javax.swing.text.ChangedCharSetException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class NexerlinUtilitys {
     private static boolean areInvasionsEnabled = true;
@@ -123,6 +125,16 @@ public class NexerlinUtilitys {
         }
 
     return lordAlignments;
+    }
+
+    public static Map<Alliance.Alignment, Float> generateLordAlignmentsFromTemplate(Lord lord) {
+        Map<Alliance.Alignment, Float> lordAlignments = new HashMap<>();
+
+        for (Alliance.Alignment alignment : Alliance.Alignment.getAlignments()) {
+            Float value = Objects.requireNonNullElse(lord.getTemplate().alignments.get(alignment.toString()),0f);
+            lordAlignments.put(alignment, value);
+        }
+        return lordAlignments;
     }
 
     public static float getAlignmentsComparison(Map<Alliance.Alignment, Float> a, Map<Alliance.Alignment, Float> b) {

--- a/src/starlords/util/Utils.java
+++ b/src/starlords/util/Utils.java
@@ -222,6 +222,16 @@ public class Utils {
         return ret;
     }
 
+	public static MarketAPI getFactionMarket(String marketName, String factionId)
+	{
+		for (MarketAPI market : getFactionMarkets(factionId))
+			if (market.getName().equalsIgnoreCase(marketName))
+			{
+				return market;
+			}
+		return null;
+	}
+
     public static float getHyperspaceDistance(SectorEntityToken entity1, SectorEntityToken entity2)
     {
         if (entity1.getContainingLocation() == entity2.getContainingLocation()) return 0;
@@ -948,8 +958,8 @@ public class Utils {
                 + "\tFaction";
 
         for (Map.Entry<Alliance.Alignment, Float> alignment : rowAlignments.entrySet()) {
-            output += "\tLord " + alignment.getKey().getName();
-            output += "\tFaction " + alignment.getKey().getName();
+            output += " \tLord " + alignment.getKey().getName();
+            output += " \tFaction " + alignment.getKey().getName();
         }
         output += System.lineSeparator();
 


### PR DESCRIPTION
- AddLordFief Command can now resolve markets based on name in addition to ids
- Campaign is now finished if campaign leader is defeated. Previously, participant lords would just have their AI broken and leader would be stuck in an endless loop of respawn -> attack
- Added Setting for "Minimum Stability to Prevent Fief Defection". set this to prevent fiefs from defecting if their stability is greater or equal than set value
- Added Intel Plugin for allied lords participating and starting raids
- Added Extra Player Council weight in calculation of next proposal to be voted
- Added possibility to configure Alignments for lords in lords.json:

"alignments": {
      "CORPORATE": -0.5,
      "TECHNOCRATIC": -0.5,
      "MILITARIST": 0.5,
      "HIERARCHICAL": 0.5,
      "DIPLOMATIC": -0.5,
      "IDEOLOGICAL": 0.5
    }